### PR TITLE
Fix bug introduced by Versionista page view changing its structure

### DIFF
--- a/capybara_script.rb
+++ b/capybara_script.rb
@@ -164,7 +164,7 @@ class VersionistaBrowser
 
       page_name = session.all(:xpath, "//div[@class='panel-heading']//h3").first.text
       page_url = session.all(:xpath, "//div[@class='panel-heading']//h3/following-sibling::a[1]").first.text
-      comparison_links = session.all(:xpath, "//*[@id='pageTableBody']/tr/td[1]/a")
+      comparison_links = session.all(:xpath, "//*[@id='pageTableBody']/tr/td[a][1]/a")
       comparison_data = parse_comparison_data(comparison_links)
       latest_diff = comparison_diff(comparison_data[:latest_comparison_url])
 


### PR DESCRIPTION
[Fixes Issue #8]
- The bug was introduced because Versionista changed
the structure of its 'page view' page. Specifically,
Versionista introduced an extra `<td>` element
in each row of the table of page versions. That
caused the prior xpath to fail to detect where
the comparison links were on the page. The revised
xpath looks for the first `<td>` that has at least
one `<a>` within it, and then looks for child `<a>`
links within that `<td>`, which solves the problem.